### PR TITLE
Update keyword to avoid duplicate in list

### DIFF
--- a/_posts/2022-02-06-adfm_vs_catheter.markdown
+++ b/_posts/2022-02-06-adfm_vs_catheter.markdown
@@ -31,7 +31,7 @@ doi: https://doi.org/10.1109/TRO.2020.3047053
 # use hyphens between words
 # use tags that are already listed on the site as much as possible
 # Use hyphens and not spaces
-tags: [ variable-stiffness, magnetic-catheter, continuum-robots, conductive-polymer]
+tags: [ variable-stiffness, magnetic-catheters, continuum-robots, conductive-polymer]
 categories: publication
 ---
 

--- a/_posts/2022-06-10-localization_hall_sensor.markdown
+++ b/_posts/2022-06-10-localization_hall_sensor.markdown
@@ -31,7 +31,7 @@ doi: https://doi.org/10.1109/LRA.2022.3181420
 # use hyphens between words
 # use tags that are already listed on the site as much as possible
 # Use hyphens and not spaces
-tags: [ remote-magnetic-navigation, magnetic-catheter, continuum-robots, localization]
+tags: [ remote-magnetic-navigation, magnetic-catheters, continuum-robots, localization]
 categories: publication
 ---
 

--- a/_posts/2022-06-29-mcr_sim.markdown
+++ b/_posts/2022-06-29-mcr_sim.markdown
@@ -32,7 +32,7 @@ doi: https://doi.org/10.1109/LRA.2022.3187249
 # use hyphens between words
 # use tags that are already listed on the site as much as possible
 # Use hyphens and not spaces
-tags: [ remote-magnetic-navigation, magnetic-catheter, continuum-robots, kinematics, soft-robotics, simulation]
+tags: [ remote-magnetic-navigation, magnetic-catheters, continuum-robots, kinematics, soft-robotics, simulation]
 categories: publication
 ---
 


### PR DESCRIPTION
Both `magnetic-catheter` and `magnetic-catheters` keywords was used. This removes the first one.